### PR TITLE
Add starter TravisCI configuration. Will pick up Travis profile from …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: java
+sudo: false
+
+jdk:
+  - openjdk7
+  - oraclejdk8
+
+after_success:
+  - mvn clean cobertura:cobertura coveralls:report


### PR DESCRIPTION
…new parent module when released.

git-svn-id: https://svn.apache.org/repos/asf/commons/proper/jxpath/trunk@1770089 13f79535-47bb-0310-9956-ffa450edef68